### PR TITLE
Implement the handling of the untagged enum unit variant

### DIFF
--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -72,6 +72,12 @@ enum Tag {
     B,
 }
 
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, DeserializeFromValue)]
+enum Untagged {
+    A,
+    B,
+}
+
 fn unknown_field_error_gen<E>(k: &str, _accepted: &[&str], location: deserr::ValuePointerRef) -> E
 where
     E: DeserializeError,
@@ -88,6 +94,8 @@ struct Example {
     x: String,
     t1: Tag,
     t2: Box<Tag>,
+    ut1: Untagged,
+    ut2: Box<Untagged>,
     n: Box<Nested>,
 }
 
@@ -485,6 +493,8 @@ fn test_de() {
         x: "X".to_owned(),
         t1: Tag::A,
         t2: Box::new(Tag::B),
+        ut1: Untagged::A,
+        ut2: Box::new(Untagged::B),
         n: Box::new(Nested {
             y: Some(vec!["Y".to_owned(), "Y".to_owned()]),
             z: None,

--- a/tests/ui/de-enum-untagged-with-data.rs
+++ b/tests/ui/de-enum-untagged-with-data.rs
@@ -3,7 +3,8 @@ use deserr::DeserializeFromValue;
 #[derive(DeserializeFromValue)]
 #[deserr(error = deserr::Error)]
 enum Enum {
-    Variant,
+    EmptyVariant,
+    VariantWithSomething { data: usize },
 }
 
 fn main() {}

--- a/tests/ui/de-enum-untagged-with-data.stderr
+++ b/tests/ui/de-enum-untagged-with-data.stderr
@@ -1,5 +1,5 @@
 error: Externally tagged enums are not supported yet by deserr. Add #[deserr(tag = "some_tag_key")]
- --> tests/ui/de-enum-no-tag.rs:3:10
+ --> tests/ui/de-enum-untagged-with-data.rs:3:10
   |
 3 | #[derive(DeserializeFromValue)]
   |          ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/de-enum-untagged-with-unnamed-data.rs
+++ b/tests/ui/de-enum-untagged-with-unnamed-data.rs
@@ -1,0 +1,10 @@
+use deserr::DeserializeFromValue;
+
+#[derive(DeserializeFromValue)]
+#[deserr(error = deserr::Error)]
+enum Enum {
+    EmptyVariant,
+    VariantWithSomething(u16),
+}
+
+fn main() {}

--- a/tests/ui/de-enum-untagged-with-unnamed-data.stderr
+++ b/tests/ui/de-enum-untagged-with-unnamed-data.stderr
@@ -1,0 +1,5 @@
+error: Enum variants with unnamed associated data aren't supported by the DeserializeFromValue derive macro.
+ --> tests/ui/de-enum-untagged-with-unnamed-data.rs:7:25
+  |
+7 |     VariantWithSomething(u16),
+  |                         ^^^^^


### PR DESCRIPTION
The variant is always deserialized as a string and gets access to the `rename_all` feature