### PR TITLE
Update dependencies

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -13,8 +13,8 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0.2"
-syn = { version = "1.0", features=["extra-traits", "parsing"]}
-convert_case = "0.5.0"
+syn = { version = "2.0", features=["extra-traits", "parsing"]}
+convert_case = "0.6.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/derive/src/attribute_parser.rs
+++ b/derive/src/attribute_parser.rs
@@ -2,13 +2,8 @@ use proc_macro2::{Ident, Span};
 use syn::{
     parenthesized,
     parse::{ParseBuffer, ParseStream},
-    parse2, Attribute, DeriveInput, Expr, ExprPath, GenericParam, LitStr, Token, WherePredicate,
+    Attribute, DeriveInput, Expr, ExprPath, GenericParam, LitStr, Token, WherePredicate,
 };
-
-// pub struct MapFieldAttribute {
-//     // from_ty: Option<syn::Type>,
-//     map_func: syn::ExprPath,
-// }
 
 /// Attributes that are applied to fields.
 #[derive(Default, Debug, Clone)]
@@ -154,12 +149,7 @@ fn parse_rename(input: &ParseBuffer) -> Result<LitStr, syn::Error> {
 impl syn::parse::Parse for FieldAttributesInfo {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut this = FieldAttributesInfo::default();
-        // parse starting right after #[deserr .... ]
-        // so first get the content inside the parentheses
 
-        let content;
-        let _ = parenthesized!(content in input);
-        let input = content;
         // consumed input: #[deserr( .... )]
 
         loop {
@@ -243,11 +233,11 @@ pub fn read_deserr_field_attributes(
 ) -> Result<FieldAttributesInfo, syn::Error> {
     let mut this = FieldAttributesInfo::default();
     for attribute in attributes {
-        if let Some(ident) = attribute.path.get_ident() {
+        if let Some(ident) = attribute.path().get_ident() {
             if ident != "deserr" {
                 continue;
             }
-            let other = parse2::<FieldAttributesInfo>(attribute.tokens.clone())?;
+            let other: FieldAttributesInfo = attribute.parse_args()?;
             this.merge(other)?;
         } else {
             continue;
@@ -519,12 +509,7 @@ fn parse_attribute_try_from(
 impl syn::parse::Parse for ContainerAttributesInfo {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut this = ContainerAttributesInfo::default();
-        // parse starting right after #[deserr .... ]
-        // so first get the content inside the parentheses
 
-        let content;
-        let _ = parenthesized!(content in input);
-        let input = content;
         // consumed input: #[deserr( .... )]
 
         loop {
@@ -655,11 +640,11 @@ pub fn read_deserr_container_attributes(
 ) -> Result<ContainerAttributesInfo, syn::Error> {
     let mut this = ContainerAttributesInfo::default();
     for attribute in attributes {
-        if let Some(ident) = attribute.path.get_ident() {
+        if let Some(ident) = attribute.path().get_ident() {
             if ident != "deserr" {
                 continue;
             }
-            let other = parse2::<ContainerAttributesInfo>(attribute.tokens.clone())?;
+            let other: ContainerAttributesInfo = attribute.parse_args()?;
             this.merge(other)?;
         } else {
             continue;
@@ -726,12 +711,7 @@ impl VariantAttributesInfo {
 impl syn::parse::Parse for VariantAttributesInfo {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut this = VariantAttributesInfo::default();
-        // parse starting right after #[deserr .... ]
-        // so first get the content inside the parentheses
 
-        let content;
-        let _ = parenthesized!(content in input);
-        let input = content;
         // consumed input: #[deserr( .... )]
 
         loop {
@@ -774,11 +754,11 @@ pub fn read_deserr_variant_attributes(
 ) -> Result<VariantAttributesInfo, syn::Error> {
     let mut this = VariantAttributesInfo::default();
     for attribute in attributes {
-        if let Some(ident) = attribute.path.get_ident() {
+        if let Some(ident) = attribute.path().get_ident() {
             if ident != "deserr" {
                 continue;
             }
-            let other = parse2::<VariantAttributesInfo>(attribute.tokens.clone())?;
+            let other: VariantAttributesInfo = attribute.parse_args()?;
             this.merge(other)?;
         } else {
             continue;

--- a/derive/src/attribute_parser.rs
+++ b/derive/src/attribute_parser.rs
@@ -158,7 +158,7 @@ impl syn::parse::Parse for FieldAttributesInfo {
             // consumed input: #[deserr( ... attr_name ... )]
             match attr_name.to_string().as_str() {
                 "rename" => {
-                    other.rename = Some(parse_rename(&input)?);
+                    other.rename = Some(parse_rename(input)?);
                 }
                 "default" => {
                     if input.peek(Token![=]) {
@@ -191,12 +191,12 @@ impl syn::parse::Parse for FieldAttributesInfo {
                     other.map = Some(func);
                 }
                 "from" => {
-                    let from_attr = parse_attribute_from(attr_name.span(), &input)?;
+                    let from_attr = parse_attribute_from(attr_name.span(), input)?;
                     // #[deserr( .. from(from_ty) = function::path::<_>)]
                     other.from = Some(from_attr);
                 }
                 "try_from" => {
-                    let try_from_attr = parse_attribute_try_from(attr_name.span(), &input)?;
+                    let try_from_attr = parse_attribute_try_from(attr_name.span(), input)?;
                     // #[deserr( .. try_from(from_ty) = function::path::<_> -> to_ty )]
                     other.try_from = Some(try_from_attr);
                 }
@@ -517,7 +517,7 @@ impl syn::parse::Parse for ContainerAttributesInfo {
             // consumed input: #[deserr( ... attr_name ... )]
             match attr_name.to_string().as_str() {
                 "rename_all" => {
-                    let rename_all = parse_rename_all(&input)?;
+                    let rename_all = parse_rename_all(input)?;
                     this.rename_all = Some(rename_all);
                     this.rename_all_span = Some(attr_name.span());
                 }
@@ -546,12 +546,12 @@ impl syn::parse::Parse for ContainerAttributesInfo {
                     this.deny_unknown_fields_span = Some(attr_name.span());
                 }
                 "from" => {
-                    let from_attr = parse_attribute_from(attr_name.span(), &input)?;
+                    let from_attr = parse_attribute_from(attr_name.span(), input)?;
                     // #[deserr( .. from(from_ty) = function::path::<_>)]
                     this.from = Some(from_attr);
                 }
                 "try_from" => {
-                    let try_from_attr = parse_attribute_try_from(attr_name.span(), &input)?;
+                    let try_from_attr = parse_attribute_try_from(attr_name.span(), input)?;
                     // #[deserr( .. try_from(from_ty) = function::path::<_> -> to_ty )]
                     this.try_from = Some(try_from_attr);
                 }
@@ -559,7 +559,7 @@ impl syn::parse::Parse for ContainerAttributesInfo {
                     // #[deserr( ... validate .. )]
                     let _eq = input.parse::<Token![=]>()?;
                     // #[deserr( ... validate = .. )]
-                    let validate_func = parse_function_returning_error(&input)?;
+                    let validate_func = parse_function_returning_error(input)?;
                     // #[deserr( ... validate = some::func<T> )]
                     this.validate = Some(validate_func);
                 }
@@ -719,10 +719,10 @@ impl syn::parse::Parse for VariantAttributesInfo {
             // consumed input: #[deserr( ... attr_name ... )]
             match attr_name.to_string().as_str() {
                 "rename" => {
-                    this.rename = Some(parse_rename(&input)?);
+                    this.rename = Some(parse_rename(input)?);
                 }
                 "rename_all" => {
-                    this.rename_all = Some(parse_rename_all(&input)?);
+                    this.rename_all = Some(parse_rename_all(input)?);
                     this.rename_all_span = Some(attr_name.span());
                 }
                 _ => {

--- a/examples/actix_web_server/Cargo.toml
+++ b/examples/actix_web_server/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 actix-http = { version = "3.2.2", default-features = false, features = ["compress-brotli", "compress-gzip", "rustls"] }
 actix-web = { version = "4.2.1", default-features = false, features = ["macros", "compress-brotli", "compress-gzip", "cookies", "rustls"] }
 anyhow = "1.0.68"
-deserr = { path = "../../" }
+deserr = { path = "../../", features = ["actix-web"] }
 env_logger = "0.10.0"
 futures = "0.3.25"
 futures-util = "0.3.25"


### PR DESCRIPTION
Update syn from 1 to 2.
The only breaking change I had to fix was going from [this attribute in v1](https://docs.rs/syn/1.0.109/syn/struct.Attribute.html) to [this one in v2](https://docs.rs/syn/latest/syn/struct.Attribute.html).

And its main impact is that when parsing the argument out of `#[deserr(doggo = bork)]`, instead of getting `(doggo = bork)`, we now get `doggo = bork`.
Which means I could remove a bunch of `parenthesis` calls.